### PR TITLE
Add plugin configuration to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ in your karma config:
 module.exports = function(config) {
   // other keys ommited for brevity
   config.set({
+    plugins: ['karma-time-stats-reporter'],
     reporters: ["dots", "time-stats"],
     // This is config options for the reporter. Listed here are the defaults if you don't provide this any options
     timeStatsReporter: {


### PR DESCRIPTION
The example will not work if karma-time-stats-reporter is not added to the plugins array.